### PR TITLE
Detect CPU count on Linux and run make -j appropriately

### DIFF
--- a/clang/setup.sh
+++ b/clang/setup.sh
@@ -36,7 +36,11 @@ tar xzf "$CLANG_SRC"
 llvm/configure "${CONFIGURE_ARGS[@]}"
 
 mkdir -p "$CLANG_PREFIX"
-make -j 8 && make install
+JOBS=8
+if [ -f /proc/cpuinfo ]; then
+       JOBS=`grep -c processor /proc/cpuinfo`
+fi
+make -j $JOBS && make install
 cp Release/bin/clang "$CLANG_PREFIX/bin/clang"
 strip -x "$CLANG_PREFIX/bin/clang"
 popd


### PR DESCRIPTION
This massively speeds up building on machines with more than 8 CPU
threads (mine has 160).

Signed-off-by: Stewart Smith <stewart@linux.vnet.ibm.com>

(I can possibly get my employer to okay a CLA if it's available, I don't want to have to sign up for a work facebook account just to view it to get it to the appropriate people though)