### PR TITLE
Ability to build Clang not only in /tmp

### DIFF
--- a/clang/setup.sh
+++ b/clang/setup.sh
@@ -107,7 +107,11 @@ fi
 # start the installation
 set -e
 echo "Installing clang..."
-TMP=`mktemp -d /tmp/clang-setup.XXXXXX`
+if [ -n "$CLANG_TMP_DIR" ]; then
+    TMP=$CLANG_TMP_DIR
+else
+    TMP=`mktemp -d /tmp/clang-setup.XXXXXX`
+fi
 pushd "$TMP"
 
 if tar --version | grep -q 'GNU'; then

--- a/clang/setup.sh
+++ b/clang/setup.sh
@@ -128,6 +128,10 @@ cp Release/bin/clang "$CLANG_PREFIX/bin/clang"
 strip -x "$CLANG_PREFIX/bin/clang"
 popd
 
-rm -rf "$TMP"
+if [ -n "$CLANG_TMP_DIR" ]; then
+    rm -rf "$TMP/*"
+else
+    rm -rf "$TMP"
+fi
 
 record_installed


### PR DESCRIPTION
Since it takes more than 16Gb it is useful to be able to specify any directory to build it in.