### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 We want to make contributing to this project as easy and transparent as
 possible.
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+
 ## Our Development Process
 The github repository https://github.com/facebook/facebook-clang-plugins is the source of truth.
 We expect some plugins to be gradually migrated to the LLVM-Clang project.


### PR DESCRIPTION
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. Let's fix it. :)

why make this change?:
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve the [Facebook Clang Plugins community profile
checklist](https://github.com/facebook/facebook-clang-plugins/community) and increase the visibility of our COC.

test plan:
Viewing it on my branch -
<img width="1018" alt="screen shot 2017-12-07 at 6 35 40 am" src="https://user-images.githubusercontent.com/1114467/33720531-15d82bf4-db19-11e7-8302-9d89b3f1db75.png">
<img width="1003" alt="screen shot 2017-12-07 at 6 35 48 am" src="https://user-images.githubusercontent.com/1114467/33720532-162c733a-db19-11e7-97f9-bff1ebd69377.png">

issue:
internal task t23481323