### PR TITLE
fix for Ubuntu 16.04

### DIFF
--- a/clang/setup.sh
+++ b/clang/setup.sh
@@ -89,6 +89,12 @@ fi
 
 platform=`uname`
 
+# strip binaries as we go unless NO_CMAKE_STRIP is passed or we are on osx
+if [ "$platform" != "Darwin" ] && [ -z $NO_CMAKE_STRIP ]; then
+  CMAKE_C_FLAGS+=" -s"
+  CMAKE_CXX_FLAGS+=" -s"
+fi
+
 CMAKE_ARGS=(
   -DCMAKE_INSTALL_PREFIX="$CLANG_PREFIX"
   -DCMAKE_BUILD_TYPE=Release

--- a/clang/setup.sh
+++ b/clang/setup.sh
@@ -89,12 +89,6 @@ fi
 
 platform=`uname`
 
-# strip binaries as we go unless NO_CMAKE_STRIP is passed or we are on osx
-if [ "$platform" != "Darwin" ] && [ -z $NO_CMAKE_STRIP ]; then
-  CMAKE_C_FLAGS+=" -s"
-  CMAKE_CXX_FLAGS+=" -s"
-fi
-
 CMAKE_ARGS=(
   -DCMAKE_INSTALL_PREFIX="$CLANG_PREFIX"
   -DCMAKE_BUILD_TYPE=Release
@@ -116,7 +110,7 @@ if [ "$platform" = "Darwin" ]; then
     )
 else
     CMAKE_ARGS+=(
-      -DCMAKE_SHARED_LINKER_FLAGS="$LDFLAGS $CMAKE_SHARED_LINKER_FLAGS -lstdc++"
+      -DCMAKE_SHARED_LINKER_FLAGS="$LDFLAGS $CMAKE_SHARED_LINKER_FLAGS -lstdc++ -fPIC"
     )
 fi
 


### PR DESCRIPTION
I got some strange errors when I compiled on Ubuntu 16.04

```
make[3]: Entering directory '/tmp/clang-setup.ChpGSW/build'
[ 98%] Building CXX object tools/lto/CMakeFiles/LTO.dir/LTODisassembler.cpp.o
clang: warning: argument unused during compilation: '-s'
[ 98%] Building CXX object tools/lto/CMakeFiles/LTO.dir/lto.cpp.o
clang: warning: argument unused during compilation: '-s'
[ 98%] Linking CXX executable ../../bin/opt
[ 98%] Linking CXX shared library ../../lib/libLTO.so
/usr/bin/ld: ../../lib/libLLVMAArch64CodeGen.a(AArch64AsmPrinter.cpp.o): relocation R_X86_64_32S against `.text' can not be used when making a shared object; recompile with -fPIC
../../lib/libLLVMAArch64CodeGen.a: error adding symbols: Bad value
clang: error: linker command failed with exit code 1 (use -v to see invocation)
tools/lto/CMakeFiles/LTO.dir/build.make:268: recipe for target 'lib/libLTO.so.7.0.0svn' failed
make[3]: *** [lib/libLTO.so.7.0.0svn] Error 1
make[3]: Leaving directory '/tmp/clang-setup.ChpGSW/build'
CMakeFiles/Makefile2:22656: recipe for target 'tools/lto/CMakeFiles/LTO.dir/all' failed
make[2]: *** [tools/lto/CMakeFiles/LTO.dir/all] Error 2
make[2]: *** Waiting for unfinished jobs....
make[3]: Leaving directory '/tmp/clang-setup.ChpGSW/build'
[ 98%] Built target opt
make[2]: Leaving directory '/tmp/clang-setup.ChpGSW/build'
Makefile:149: recipe for target 'all' failed
make[1]: *** [all] Error 2
make[1]: Leaving directory '/tmp/clang-setup.ChpGSW/build'
Makefile:254: recipe for target 'clang_setup' failed
make: *** [clang_setup] Error 2
```

There was a warning about the `-s` flag, so I deleted it. For some reason it mentions AArch64, but I'm on Intel x64. I added `-fPIC`, it infer compiled, and it runs.

gcc = gcc (Ubuntu 5.4.0-6ubuntu1~16.04.9) 5.4.0 20160609
ld = GNU ld (GNU Binutils for Ubuntu) 2.26.1
