### PR TITLE
Github Actions workflow for CI/CD

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -1,0 +1,89 @@
+name: Build clang
+on: push
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get Changed Files
+        id: files-changed
+        # don't run this if a commit is appropriately tagged, we'll build clang anyway
+        if: ${{ !(startsWith(github.ref, 'refs/tags/v.')) }}
+        uses: trilom/file-changes-action@v1.2.4
+        with:
+          output: ' '
+
+      - name: Check clang/ Changed
+        id: clang-changed
+        # don't run this if a commit is appropriately tagged, we'll build clang anyway
+        if: ${{ !(startsWith(github.ref, 'refs/tags/v.')) }}
+        run: |
+          MODIFIED=0
+
+          echo "added:    ${{ steps.files-changed.outputs.files_added }}"
+          echo "modified: ${{ steps.files-changed.outputs.files_modified }}"
+          echo "removed:  ${{ steps.files-changed.outputs.files_removed }}"
+
+          for f in $(echo '${{ steps.files-changed.outputs.files_added }}'); do
+            if [[ "$f" == "clang/"* ]]; then
+              echo "added to clang/: $f"
+              MODIFIED=1
+            fi
+          done
+
+          for f in $(echo '${{ steps.files-changed.outputs.files_modified }}'); do
+            if [[ "$f" == "clang/"* ]]; then
+              echo "clang/ modified: $f"
+              MODIFIED=1
+            fi
+          done
+
+          for f in $(echo '${{ steps.files-changed.outputs.files_removed }}'); do
+            if [[ "$f" == "clang/"* ]]; then
+              echo "removed from clang/: $f"
+              MODIFIED=1
+            fi
+          done
+
+          if [ $MODIFIED -eq 1 ]; then
+            echo "clang/ directory changed: rebuilding clang."
+            echo "::set-output name=clang-changed::1"
+          else
+            echo "No clang/ files touched: skipping build."
+            echo "::set-output name=clang-changed::0"
+          fi
+
+      - name: Build Clang
+        id: build-clang
+        # allow clang to be manually built by pushing a tag named "v.*"
+        if: ${{ steps.clang-changed.outputs.clang-changed == 1 || startsWith(github.ref, 'refs/tags/v.') }}
+        run: |
+          ./clang/setup.sh
+          tar -cvzf "clang-install-${{ matrix.os }}.tar.gz" -C clang install/
+
+      - name: Create Tag
+        id: create-tag
+        # create a new tag: v.{sha}
+        # only run on pushes when clang has changed and the ref is NOT already tagged "v.*"
+        if: ${{ github.event_name == 'push' && steps.clang-changed.outputs.clang-changed == 1 && !(startsWith(github.ref, 'refs/tags/v.')) }}
+        run: |
+          # note: this creates a "lightweight tag" (not an annotated tag)
+          curl -s -X POST https://api.github.com/repos/${{ github.repository }}/git/refs \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -d '{"ref": "refs/tags/v.${{ github.sha }}", "sha": "${{ github.sha }}" }'
+
+      - name: Create Clang Release
+        id: create-release
+        # create a new release only on push events, if clang has changed or the tag is named 'v.*'
+        if: ${{ github.event_name == 'push' && ( steps.clang-changed.outputs.clang-changed == 1 || startsWith(github.ref, 'refs/tags/v.') ) }}
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: Release ${{ github.sha }}
+          tag_name: v.${{ github.sha }}
+          files: clang-install-${{ matrix.os }}.tar.gz


### PR DESCRIPTION
Now that Github Actions is a lot more mature, try to use it for building `clang`. This could allow [facebook/infer](https://github.com/facebook/infer) to use the output clang artifacts for also testing builds of Infer with C plugins enabled (previously disabled because clang builds take far too long).

Old work in #18 - tried to use Travis, but clang takes >1hr to build so workflows time out, figured it wasn't worth the hassle.

This workflow is WIP for two reasons.

1. How often to run?

I'm not sure about how often maintainers would like it to run. The build job ONLY builds `clang` using `clang/setup.sh`, and this repo's custom clang is changed infrequently. I set up logic in this workflow to only build the custom clang anytime files in the `clang/` directory are added, modified, or removed. However, maintainers may prefer rebuilding on each commit (probably a waste) or building on a schedule e.g. using cron to build every week in addition to whenever `clang/` files are changed.

2. Release uploading

This workflow currently only uploads an `artifact`, but GitHub artifacts are apparently supposed to be used for storing files so that different workflows can access them (there is no API endpoint for getting "most recent artifact"). Instead, it would be better to upload to Releases (you could use [create-release](https://github.com/actions/create-release) and [upload-release-asset](https://github.com/actions/upload-release-asset) actions together) so that Infer builds could use a specific tagged version. That doesn't completely fit in your install process so I didn't want to make assumptions.

Uploading to Releases could also allow you to remove the "check if clang files changed" steps in this workflow - you could set it to build on only certain tags (e.g. `clang-v*`) and then tag a commit whenever you change clang stuff and want it to rebuild.